### PR TITLE
给 XPRootNavigationController 添加 visibleViewController 的 getter 方法

### DIFF
--- a/NavigationContainer/XPRootNavigationController.m
+++ b/NavigationContainer/XPRootNavigationController.m
@@ -266,6 +266,15 @@ UIKIT_STATIC_INLINE void xp_swizzled(Class class, SEL originalSelector, SEL swiz
     return [NSArray arrayWithArray:vcs];
 }
 
+// Return modal view controller if it exists. Otherwise the top view controller.
+- (UIViewController *)visibleViewController {
+    UIViewController *vc = [super visibleViewController];
+    if (vc == self.topViewController) {
+        return XPUnwrapViewController(vc);
+    }
+    return vc;
+}
+
 @end
 
 


### PR DESCRIPTION
由于 XPRootNavigationController 改变了 navigationController 的内部类结构，导致在调用 XPRootNavigationController 的属性 visibleViewController 时得到了错误结果。为了解决这个问题，给 XPRootNavigationController 重写 visibleViewController 的 getter 方法即可。